### PR TITLE
Feature/fix video time

### DIFF
--- a/BitmovinAnalyticsCollector.podspec
+++ b/BitmovinAnalyticsCollector.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'BitmovinAnalyticsCollector'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = 'iOS library that allows you to monitor your iOS video playback with Bitmovin Analytics'
 
   s.description      = <<-DESC

--- a/BitmovinAnalyticsCollector/Classes/adapters/AVPlayerAdapter.swift
+++ b/BitmovinAnalyticsCollector/Classes/adapters/AVPlayerAdapter.swift
@@ -176,7 +176,7 @@ class AVPlayerAdapter: NSObject, PlayerAdapter {
 
         // Duration
         if let duration = player?.currentItem?.duration, CMTIME_IS_NUMERIC(_: duration) {
-            eventData.videoDuration = Int(CMTimeGetSeconds(duration) * 1000)
+            eventData.videoDuration = Int64(CMTimeGetSeconds(duration) * BitmovinAnalytics.msInSec)
         }
 
         // isCasting

--- a/BitmovinAnalyticsCollector/Classes/adapters/BitmovinPlayerAdapter.swift
+++ b/BitmovinAnalyticsCollector/Classes/adapters/BitmovinPlayerAdapter.swift
@@ -40,7 +40,7 @@ class BitmovinPlayerAdapter: NSObject, PlayerAdapter {
 
         //Duration
         if !player.duration.isNaN && !player.duration.isInfinite {
-            eventData.videoDuration = Int(player.duration) * 1000
+            eventData.videoDuration = Int64(player.duration * BitmovinAnalytics.msInSec)
         }
 
         //isCasting

--- a/BitmovinAnalyticsCollector/Classes/analytics/BitmovinAnalytics.swift
+++ b/BitmovinAnalyticsCollector/Classes/analytics/BitmovinAnalytics.swift
@@ -69,7 +69,7 @@ public class BitmovinAnalytics {
         eventData.duration = duration
 
         if let timeStart = stateMachine.videoTimeStart {
-            eventData.videoTimeEnd = Int64(CMTimeGetSeconds(timeStart) * BitmovinAnalytics.msInSec)
+            eventData.videoTimeStart = Int64(CMTimeGetSeconds(timeStart) * BitmovinAnalytics.msInSec)
         }
         if let timeEnd = stateMachine.videoTimeEnd {
             eventData.videoTimeEnd = Int64(CMTimeGetSeconds(timeEnd) * BitmovinAnalytics.msInSec)

--- a/BitmovinAnalyticsCollector/Classes/data/EventData.swift
+++ b/BitmovinAnalyticsCollector/Classes/data/EventData.swift
@@ -13,7 +13,7 @@ public class EventData: Codable {
     var isLive: Bool = false
     var isCasting: Bool? = false
     var isMuted: Bool? = false
-    var videoDuration: Int = 0
+    var videoDuration: Int64 = 0
     var time: Double?
     var videoWindowWidth: Int = 0
     var videoWindowHeight: Int = 0

--- a/BitmovinAnalyticsCollector/Classes/util/Util.swift
+++ b/BitmovinAnalyticsCollector/Classes/util/Util.swift
@@ -33,7 +33,7 @@ class Util {
     }
 
     static func doubleToCMTime(double: Double) -> CMTime? {
-        return CMTimeMake(Int64(double), 1000)
+        return CMTimeMake(Int64(double), 1)
     }
 
     static func toJson<T: Codable>(object: T?) -> String {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ BitmovinAnalyticsCollector is available through [CocoaPods](http://cocoapods.org
 it, simply add the following line to your Podfile:
 
 ```ruby
-  pod 'BitmovinAnalyticsCollector', git: 'https://github.com/bitmovin/bitmovin-analytics-collector-ios.git', tag:'1.3.1'
+  pod 'BitmovinAnalyticsCollector', git: 'https://github.com/bitmovin/bitmovin-analytics-collector-ios.git', tag:'1.3.2'
   pod 'BitmovinPlayer', git: 'https://github.com/bitmovin/bitmovin-player-ios-sdk-cocoapod.git', tag: '2.9.0'
 
   use_frameworks!


### PR DESCRIPTION
Some minor fixes:

1. `videoStartTime` was not being set. Fixed that
1. `videoStartTime` and `videoStartEnd` were being sent in seconds, now changed to milliseconds to match the other collectors.
1. `videoDuration` was changed to Int64 as it holds time in milliseconds.