### PR TITLE
Update source_files to only include swift files

### DIFF
--- a/BitmovinAnalyticsCollector.podspec
+++ b/BitmovinAnalyticsCollector.podspec
@@ -15,7 +15,7 @@ DESC
 
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
-  s.source_files = 'BitmovinAnalyticsCollector/Classes/**/*'
+  s.source_files = 'BitmovinAnalyticsCollector/Classes/**/*.{swift}'
   s.tvos.dependency 'BitmovinPlayer', '~>2.11.0'
   s.ios.dependency 'BitmovinPlayer', '~>2.11.0'
 


### PR DESCRIPTION
## Description
With Xcode 10 (iOS 12) Apple introduces a new `Build System` which is more rigorous with conflicts during the build step. In this case the name `Info.plist` is ambiguous.

## Fix
Do not include the `Info.plist` file in `source_files`.