### PR TITLE
Allow >= 2.11 versions of BitmovinPlayer pod

### DIFF
--- a/BitmovinAnalyticsCollector.podspec
+++ b/BitmovinAnalyticsCollector.podspec
@@ -16,7 +16,7 @@ DESC
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.source_files = 'BitmovinAnalyticsCollector/Classes/**/*'
-  s.tvos.dependency 'BitmovinPlayer', '~>2.11.0'
-  s.ios.dependency 'BitmovinPlayer', '~>2.11.0'
+  s.tvos.dependency 'BitmovinPlayer', '~>2.11'
+  s.ios.dependency 'BitmovinPlayer', '~>2.11'
 
 end


### PR DESCRIPTION
## Description
Currently the `podspec` specifies `BitmovinPlayer` version 2.11.x. 
We can change this to >=2.11 to also include latest release 2.12.0 for example.