### PR TITLE
Specify swift version to 4.0

### DIFF
--- a/BitmovinAnalyticsCollector.podspec
+++ b/BitmovinAnalyticsCollector.podspec
@@ -18,5 +18,6 @@ DESC
   s.source_files = 'BitmovinAnalyticsCollector/Classes/**/*'
   s.tvos.dependency 'BitmovinPlayer', '~>2.11.0'
   s.ios.dependency 'BitmovinPlayer', '~>2.11.0'
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 
 end


### PR DESCRIPTION
## Description
This pod is written in `Swift 4.0` when installing this pod to a iOS 12 (Xcode 10) project this will not compile due to syntax errors in `Swift 4.2`

## Fix
This PR specifies the Swift version for the Pod Target to 4.0