### PR TITLE
Update swift version specification for cocoapods >= 1.4

### DIFF
--- a/BitmovinAnalyticsCollector.podspec
+++ b/BitmovinAnalyticsCollector.podspec
@@ -18,6 +18,6 @@ DESC
   s.source_files = 'BitmovinAnalyticsCollector/Classes/**/*.{swift}'
   s.tvos.dependency 'BitmovinPlayer', '~>2.11'
   s.ios.dependency 'BitmovinPlayer', '~>2.11'
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.swift_version = '4.0'
 
 end

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ A [full example app]() can be seen in the github repo
 
 ## Installation
 
-BitmovinAnalyticsCollector is available through [CocoaPods](http://cocoapods.org). To install
+BitmovinAnalyticsCollector is available through [CocoaPods](http://cocoapods.org). We depend on `cocoapods` version `>= 1.4`. To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-  pod 'BitmovinAnalyticsCollector', git: 'https://github.com/bitmovin/bitmovin-analytics-collector-ios.git', tag:'1.5.0'
+  pod 'BitmovinAnalyticsCollector', git: 'https://github.com/bitmovin/bitmovin-analytics-collector-ios.git', tag: '1.5.0'
   pod 'BitmovinPlayer', git: 'https://github.com/bitmovin/bitmovin-player-ios-sdk-cocoapod.git', tag: '2.11.0'
 
   use_frameworks!


### PR DESCRIPTION
## Description
Unfortunately i used an [outdated](https://github.com/CocoaPods/CocoaPods/issues/7327) variant to specify the swift version. This will update to the DSL to cocoapods >= 1.4