### PR TITLE
Feature/supported video codecs

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/BitmovinPlayerAdapter.swift
+++ b/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/BitmovinPlayerAdapter.swift
@@ -49,7 +49,9 @@ class BitmovinPlayerAdapter: NSObject, PlayerAdapter {
         eventData.isLive = player.isLive
 
         //version
-        eventData.version = "1.0"
+        if let sdkVersion = Bundle(for: BitmovinPlayer.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
+            eventData.version = sdkVersion
+        }
 
         // streamForamt, hlsUrl
         eventData.streamForamt = "hls"

--- a/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
@@ -123,6 +123,7 @@ extension BitmovinAnalyticsInternal: StateMachineDelegate {
         // Hard coding 1 as the player startup time to workaround a Dashboard issue
         eventData?.playerStartupTime = 1
         eventData?.startupTime = duration+1
+        eventData?.supportedVideoCodecs = Util.getSupportedVideoCodecs()
 
         eventData?.state = "startup"
         sendEventData(eventData: eventData)

--- a/BitmovinAnalyticsCollector/Classes/Collector/data/EventData.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/data/EventData.swift
@@ -63,6 +63,7 @@ public class EventData: Codable {
     #endif
     var videoCodec: String?
     var audioCodec: String?
+    var supportedVideoCodecs: [String]?
 
 
     public init(config: BitmovinAnalyticsConfig, impressionId: String) {

--- a/BitmovinAnalyticsCollector/Classes/Collector/data/EventData.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/data/EventData.swift
@@ -60,6 +60,14 @@ public class EventData: Codable {
     var platform: String = "iOS"
     #elseif os(tvOS)
     var platform: String = "tvOS"
+    #elseif os(watchOS)
+    var platform: String = "watchOS"
+    #elseif os(macOS)
+    var platform: String = "macOS"
+    #elseif os(Linux)
+    var platform: String = "Linux"
+    #else
+    var platform: String = "unknown"
     #endif
     var videoCodec: String?
     var audioCodec: String?

--- a/BitmovinAnalyticsCollector/Classes/Collector/util/Util.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/util/Util.swift
@@ -75,6 +75,14 @@ class Util {
         
         
     }
+    
+    static func getSupportedVideoCodecs() -> [String] {
+        var codecs = ["avc"];
+        if #available(iOS 11, *) {
+            codecs.append("hevc")
+        }
+        return codecs;
+    }
 }
 
 extension Date {

--- a/BitmovinAnalyticsCollector/Classes/Collector/util/Util.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/util/Util.swift
@@ -78,7 +78,7 @@ class Util {
     
     static func getSupportedVideoCodecs() -> [String] {
         var codecs = ["avc"];
-        if #available(iOS 11, *) {
+        if #available(iOS 11, tvOS 11, *) {
             codecs.append("hevc")
         }
         return codecs;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Added
+
+- `supportedVideoCodecs` in outgoing payload
+
+### Fixed
+
+- Collector didn't report the correct version of the Bitmovin player
+- Added additional cases to the  `platform` field (`watchOS`,  `macOS`, `Linux` and `unknown`) 
+
 ## 1.7.0
 
 ### Added

--- a/Example/BitmovinAnalyticsCollector/Info.plist
+++ b/Example/BitmovinAnalyticsCollector/Info.plist
@@ -31,6 +31,8 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>BitmovinPlayerLicenseKey</key>
+	<string>a6e31908-550a-4f75-b4bc-a9d89880a733</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
- Added `supportVideoCodecs` to sample (`hevc` support in iOS > 11, `av1` and `vp9` are not supported)
- Fixed Bitmovin Player version reporting
- Added more platform switches, as at the moment there are samples that don't have the platform field set