### PR TITLE
Resetting collector on `onSourceUnloaded`

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/BitmovinPlayerAdapter.swift
+++ b/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/BitmovinPlayerAdapter.swift
@@ -149,4 +149,8 @@ extension BitmovinPlayerAdapter: PlayerListener {
             stateMachine.transitionState(destinationState: .playing, time: Util.doubleToCMTime(double: player.currentTime))
         }
     }
+    
+    func onSourceUnloaded(_ event: SourceUnloadedEvent) {
+        stateMachine.reset()
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+### Fixed
+
+- Collector didn't reset on `onSourceUnloaded` and continued sending samples with the inital `impression_id`, if `detachPlayer` wasn't called 
 
 
 ## 1.7.0


### PR DESCRIPTION
### Work

- Issue(s): https://github.com/bitmovin/analytics-issues/issues/456
- Description: Resetting the collector on `onSourceUnloaded`, which will create a new `impression_id` as well as resets all the timing information