### PR TITLE
Feature/avpayer errortracking

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/BitmovinPlayerAdapter.swift
+++ b/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/BitmovinPlayerAdapter.swift
@@ -5,7 +5,7 @@ class BitmovinPlayerAdapter: NSObject, PlayerAdapter {
     private let stateMachine: StateMachine
     private let config: BitmovinAnalyticsConfig
     private var player: BitmovinPlayer
-    private var errorCode: UInt?
+    private var errorCode: Int?
     private var errorDescription: String?
 
     init(player: BitmovinPlayer, config: BitmovinAnalyticsConfig, stateMachine: StateMachine) {
@@ -137,7 +137,7 @@ extension BitmovinPlayerAdapter: PlayerListener {
     }
 
     func onError(_ event: ErrorEvent) {
-        errorCode = event.code
+        errorCode = Int(event.code)
         errorDescription = event.description
         stateMachine.transitionState(destinationState: .error, time: Util.doubleToCMTime(double: player.currentTime))
     }

--- a/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
@@ -44,6 +44,7 @@ public class BitmovinAnalyticsInternal {
         guard let data = eventData else {
             return
         }
+        print("error message: ", eventData?.errorMessage, ", error code: ", eventData?.errorCode)
         eventDataDispatcher.add(eventData: data)
     }
 
@@ -76,11 +77,11 @@ extension BitmovinAnalyticsInternal: StateMachineDelegate {
 
     func stateMachineDidEnterError(_ stateMachine: StateMachine, data: [AnyHashable: Any]?) {
         let eventData = createEventData(duration: 0)
-        if((data?[BitmovinAnalyticsInternal.ErrorCodeKey]) != nil) {
-            eventData?.errorCode = data?[BitmovinAnalyticsInternal.ErrorCodeKey] as! Int?
+        if let errorCode = data?[BitmovinAnalyticsInternal.ErrorCodeKey] {
+            eventData?.errorCode = errorCode as? Int
         }
-        if((data?[BitmovinAnalyticsInternal.ErrorMessageKey]) != nil) {
-            eventData?.errorMessage = data?[BitmovinAnalyticsInternal.ErrorMessageKey] as! String?
+        if let errorMessage = data?[BitmovinAnalyticsInternal.ErrorMessageKey] {
+            eventData?.errorMessage = errorMessage as? String
         }
         sendEventData(eventData: eventData)
     }

--- a/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
@@ -5,6 +5,9 @@ import Foundation
  * supports analytics on AVPlayer video players
  */
 public class BitmovinAnalyticsInternal {
+    public static let ErrorMessageKey = "errorMessage"
+    public static let ErrorCodeKey = "errorCode"
+    
     static let msInSec = 1000.0
     internal var config: BitmovinAnalyticsConfig
     internal var stateMachine: StateMachine
@@ -71,8 +74,14 @@ extension BitmovinAnalyticsInternal: StateMachineDelegate {
         sendEventData(eventData: eventData)
     }
 
-    func stateMachineDidEnterError(_ stateMachine: StateMachine) {
+    func stateMachineDidEnterError(_ stateMachine: StateMachine, data: [AnyHashable: Any]?) {
         let eventData = createEventData(duration: 0)
+        if((data?[BitmovinAnalyticsInternal.ErrorCodeKey]) != nil) {
+            eventData?.errorCode = data?[BitmovinAnalyticsInternal.ErrorCodeKey] as! Int?
+        }
+        if((data?[BitmovinAnalyticsInternal.ErrorMessageKey]) != nil) {
+            eventData?.errorMessage = data?[BitmovinAnalyticsInternal.ErrorMessageKey] as! String?
+        }
         sendEventData(eventData: eventData)
     }
 

--- a/BitmovinAnalyticsCollector/Classes/Collector/data/EventData.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/data/EventData.swift
@@ -5,7 +5,7 @@ public class EventData: Codable {
     var path: String?
     var language: String
     var userAgent: String?
-    var errorCode: UInt?
+    var errorCode: Int?
     var errorMessage: String?
     var screenWidth: Int?
     var screenHeight: Int?

--- a/BitmovinAnalyticsCollector/Classes/Collector/stateMachines/PlayerState.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/stateMachines/PlayerState.swift
@@ -9,14 +9,14 @@ public enum PlayerState: String {
     case qualitychange
     case seeking
 
-    func onEntry(stateMachine: StateMachine, timestamp _: Int64, destinationState _: PlayerState) {
+    func onEntry(stateMachine: StateMachine, timestamp _: Int64, destinationState _: PlayerState, data: [AnyHashable : Any]?) {
         switch self {
         case .setup:
             return
         case .buffering:
             return
         case .error:
-            stateMachine.delegate?.stateMachineDidEnterError(stateMachine)
+            stateMachine.delegate?.stateMachineDidEnterError(stateMachine, data: data)
             return
         case .playing, .paused:
             if (stateMachine.firstReadyTimestamp == nil) {

--- a/BitmovinAnalyticsCollector/Classes/Collector/stateMachines/StateMachine.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/stateMachines/StateMachine.swift
@@ -43,7 +43,7 @@ public class StateMachine {
         print("Generated Bitmovin Analytics impression ID: " +  impressionId.lowercased())
     }
 
-    public func transitionState(destinationState: PlayerState, time: CMTime?) {
+    public func transitionState(destinationState: PlayerState, time: CMTime?, data: [AnyHashable : Any]? = nil) {
         if state == destinationState {
             return
         } else if state == .buffering && destinationState == .qualitychange {
@@ -55,7 +55,7 @@ public class StateMachine {
             state = destinationState
             enterTimestamp = timestamp
             videoTimeStart = videoTimeEnd
-            state.onEntry(stateMachine: self, timestamp: timestamp, destinationState: destinationState)
+            state.onEntry(stateMachine: self, timestamp: timestamp, destinationState: destinationState, data: data)
         }
     }
 

--- a/BitmovinAnalyticsCollector/Classes/Collector/stateMachines/StateMachineDelegate.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/stateMachines/StateMachineDelegate.swift
@@ -3,7 +3,7 @@ import Foundation
 protocol StateMachineDelegate: class {
     func stateMachineDidExitSetup(_ stateMachine: StateMachine)
     func stateMachine(_ stateMachine: StateMachine, didExitBufferingWithDuration duration: Int64)
-    func stateMachineDidEnterError(_ stateMachine: StateMachine)
+    func stateMachineDidEnterError(_ stateMachine: StateMachine, data: [AnyHashable : Any]?)
     func stateMachine(_ stateMachine: StateMachine, didExitPlayingWithDuration duration: Int64)
     func stateMachine(_ stateMachine: StateMachine, didExitPauseWithDuration duration: Int64)
     func stateMachineDidQualityChange(_ stateMachine: StateMachine)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 
+### Fixed
+
+- Collector didn't report errors when using the `AVPlayerCollector` 
+
 
 ## 1.7.0
 


### PR DESCRIPTION
### Work
- Issue(s): https://github.com/bitmovin/analytics-issues/issues/593
- Description: Added error handling to the AVPlayer collector. Changed the data type of the error code from UInt to Int, as error codes can be negative for the AVPlayer.

Tracking errors according to: https://qiita.com/hiroakit/items/8a91377867db18590d2c