### PR TITLE
Update BitmovinAnalyticsInternal.swift

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
+++ b/BitmovinAnalyticsCollector/Classes/Collector/analytics/BitmovinAnalyticsInternal.swift
@@ -71,6 +71,7 @@ extension BitmovinAnalyticsInternal: StateMachineDelegate {
 
     func stateMachine(_ stateMachine: StateMachine, didExitBufferingWithDuration duration: Int64) {
         let eventData = createEventData(duration: duration)
+        eventData?.buffered = duration
         sendEventData(eventData: eventData)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Collector didn't populate `buffered` field when buffering occured
 - Collector didn't correctly report `streamFormat`, `m3u8Url`, `mpdUrl` or `progUrl`
 - `videoTimeStart` and `videoTimeEnd` were not set when sending out heartbeats
 - Collector didn't report errors when using the `AVPlayerCollector` 


### PR DESCRIPTION
### Work
- Issue(s): https://github.com/bitmovin/analytics-issues/issues/602
- Description: Buffering time wasn't set in the statemachine callback
