### PR TITLE
Fix player instantiation in tvOS example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- tvOS example project did not work anymore due to naming change of `BitmovinPlayer` to `Player` in `2.51.0`
+
 ## 1.18.1
 
 ### Added

--- a/Example/tvOS Example for BitmovinAnalyticsCollector/ViewController.swift
+++ b/Example/tvOS Example for BitmovinAnalyticsCollector/ViewController.swift
@@ -11,7 +11,7 @@ import BitmovinPlayer
 import BitmovinAnalyticsCollector
 
 class ViewController: UIViewController {
-    private var player: BitmovinPlayer?
+    private var player: Player?
     private var analyticsCollector: BitmovinAnalytics
     private var config: BitmovinAnalyticsConfig
 
@@ -51,7 +51,7 @@ class ViewController: UIViewController {
             try config.setSourceItem(url: streamUrl)
             config.playbackConfiguration = playbackConfig
             // Create player based on player configuration
-            let player = BitmovinPlayer(configuration: config)
+            let player = Player(configuration: config)
             analyticsCollector.attachBitmovinPlayer(player: player)
 
             // Create player view and pass the player instance to it


### PR DESCRIPTION
### Work
- Fixes: Untracked
- Description: tvOS example did not work anymore as `BitmovinPlayer` was renamed to `Player` in [2.51.0](https://bitmovin.com/docs/player/releases/ios/ios-2-51-0). Background and details can be found in the 2.51.0 migration guide: https://bitmovin.com/docs/player/articles/migration-guide-for-api-changes-in-ios-tvos-player-sdk-v2-51-0

### Checklist

- [x] Updated CHANGELOG.md
