### PR TITLE
Fix Xcode 12.5 errors

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/util/BitmovinPlayerUtil.swift
+++ b/BitmovinAnalyticsCollector/Classes/BitmovinPlayer/Classes/util/BitmovinPlayerUtil.swift
@@ -25,12 +25,12 @@ public class BitmovinPlayerUtil {
     
     static func getAdTagTypeFromAdTag(adTag: AdTag)-> AnalyticsAdTagType {
         switch adTag.type {
-            case BMPAdTagType.VAST:
-                return AnalyticsAdTagType.VAST;
-            case BMPAdTagType.VMAP:
-                return AnalyticsAdTagType.VMAP;
+            case .VAST:
+                return .VAST;
+            case .VMAP:
+                return .VMAP;
             default:
-                return AnalyticsAdTagType.UNKNOWN;
+                return .UNKNOWN;
         }
     }
     


### PR DESCRIPTION
### Work
- Fixes: 
![image (24)](https://user-images.githubusercontent.com/141675/116451931-fb5cb780-a811-11eb-858c-e54e865bfd8c.png)

- Description: The above error occurs when using the `BitmovinAnalyticsCollector/Core` and `BitmovinAnalyticsCollector/BitmovinPlayer` pods on Xcode 12.5.

This commit fixes this error and makes this method slightly more idiomatic swift.

### Checklist

- [ ] Updated CHANGELOG.md
