### PR TITLE
Fix archive builds by removing unnecessary `@testable` from AVPlayerAdapterFactory.swift

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/AVPlayerV2/AVPlayerAdapterFactory.swift
+++ b/BitmovinAnalyticsCollector/Classes/AVPlayerV2/AVPlayerAdapterFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 import AVFoundation
 
 #if SWIFT_PACKAGE
-@testable import CoreCollector
+import CoreCollector
 #endif
 
 class AVPlayerAdapterFactory {


### PR DESCRIPTION
### Work
AFAIK, `@testable` should only be included in unit test files where you're importing a library to test. `AVPlayerAdapterFactory` was incorrectly using `@testable` when importing `CoreCollector` which caused an error when using the SDK with Swift Package Manager and trying to create an archive build:

![Screenshot 2022-06-24 at 15 16 20@2x](https://user-images.githubusercontent.com/138576/175554411-9dcd495e-04ef-4da9-846a-1f43ca6bd5d1.png)

Fixed here by simply removing the `@testable`

### Checklist

- [ ] Updated CHANGELOG.md _(Wasn't clear if I should add a version or whatever so I didn't touch it)_
