### PR TITLE
Fix archive builds for SPM setup by removing unnecessary @testable.

### DIFF
--- a/BitmovinAnalyticsCollector/Classes/AVPlayerV2/AVPlayerAdapterFactory.swift
+++ b/BitmovinAnalyticsCollector/Classes/AVPlayerV2/AVPlayerAdapterFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 import AVFoundation
 
 #if SWIFT_PACKAGE
-@testable import CoreCollector
+import CoreCollector
 #endif
 
 class AVPlayerAdapterFactory {


### PR DESCRIPTION
### Work
@testable should only be included in unit test files where you're importing a library to test. AVPlayerAdapterFactory was incorrectly using @testable when importing CoreCollector, which caused an error when using the SDK with Swift Package Manager and trying to create an archive build:

<img width="1097" alt="Screenshot 2022-11-25 at 12 06 39" src="https://user-images.githubusercontent.com/481425/203957335-68d7f209-d540-499e-886b-b5342cadc12f.png">

Fixed here by simply removing the @testable

### Checklist

- [ ] Updated CHANGELOG.md
