### PR TITLE
Fix link to full demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ config.isLive = true
 config.ads = true
 ```
 
-A full example app can be seen [here](https://github.com/bitmovin/bitmovin-analytics-collector-ios/tree/develop/CollectorDemoApp).
+A full example app can be seen [here](https://github.com/bitmovin/bitmovin-analytics-collector-ios/tree/main/CollectorDemoApp).
 
 ## Installation
 


### PR DESCRIPTION
Link to full example app in README.md was pointing to `develop` branch, which doesn't exist anymore. Changed the link to point to the demo app in the `main` branch instead.